### PR TITLE
Allowed command to be specified as list

### DIFF
--- a/src/anki-external-editor/__init__.py
+++ b/src/anki-external-editor/__init__.py
@@ -12,26 +12,31 @@ from .utils import find_executable, is_executable
 def get_editor():
     config = mw.addonManager.getConfig(__name__)
     user_choice = config.get("editor")
-    if is_executable(user_choice):
-        return user_choice
-    editors = [
-        user_choice,
-        user_choice + ".exe",
-        "notepad++.exe",
-        "notepad.exe",
-        "code --wait",
-        "gvim -f",
-        "vim -gf",
-        "atom",
-        "atom.exe",
-        "gedit",
-    ]
-    if sys.platform == "darwin":
-        editors.append("open -t")
-    for editor in editors:
-        command = find_executable(editor)
+    if isinstance(user_choice, list):
+        command = find_executable(user_choice[0])
         if command:
-            return command
+            return [command] + user_choice[slice(1)]
+    elif is_executable(user_choice):
+        return [user_choice]
+    else:
+        editors = [
+            user_choice,
+            user_choice + ".exe",
+            "notepad++.exe",
+            "notepad.exe",
+            "code --wait",
+            "gvim -f",
+            "vim -gf",
+            "atom",
+            "atom.exe",
+            "gedit",
+        ]
+        if sys.platform == "darwin":
+            editors.append("open -t")
+        for editor in editors:
+            command = find_executable(editor)
+            if command:
+                return command.split()
 
     raise RuntimeError("Could not find external editor")
 
@@ -43,7 +48,7 @@ def edit(text):
     with io.open(filename, 'w', encoding='utf-8') as file:
         file.write(text)
 
-    cmd_list = editor.split() + [filename]
+    cmd_list = editor + [filename]
     proc = subprocess.Popen(cmd_list, close_fds=True)
     proc.communicate()
 

--- a/src/anki-external-editor/__init__.py
+++ b/src/anki-external-editor/__init__.py
@@ -15,7 +15,7 @@ def get_editor():
     if isinstance(user_choice, list):
         command = find_executable(user_choice[0])
         if command:
-            return [command] + user_choice[slice(1, len(user_choice))]
+            return [command] + user_choice[1:]
     elif is_executable(user_choice):
         return [user_choice]
     else:

--- a/src/anki-external-editor/__init__.py
+++ b/src/anki-external-editor/__init__.py
@@ -15,7 +15,7 @@ def get_editor():
     if isinstance(user_choice, list):
         command = find_executable(user_choice[0])
         if command:
-            return [command] + user_choice[slice(1)]
+            return [command] + user_choice[slice(1, len(user_choice))]
     elif is_executable(user_choice):
         return [user_choice]
     else:


### PR DESCRIPTION
I was using to escape a space in an argument, but the script will split on all spaces.
The allows the command to be specified as:
```
["command", "arg1", "arg with spaces"]
```